### PR TITLE
Search in all projects by default

### DIFF
--- a/web/menu.jspf
+++ b/web/menu.jspf
@@ -175,7 +175,7 @@ org.opensolaris.opengrok.web.Util"
             // ondblclick="javascript:goFirstProject();"
         %>
         <option value="<%= e.getValue() %>"<%
-            if (pRequested.contains(e.getKey())) {
+            if (pRequested.contains(e.getKey()) || pRequested.isEmpty()) {
             %> selected="selected"<%
             }
             %>><%= e.getValue() %></option><%


### PR DESCRIPTION
A user using grok for the first time should not have to select a project to search into but should automatically search in all projects.
